### PR TITLE
fix: routes linked and authors added

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,44 +1,35 @@
+import { Link } from 'react-router-dom';
+import { authors } from '../utils/constants';
+
 function Footer() {
   return (
     <div className="container">
-      <a
-        href="/"
-        className="mb-3 me-2 mb-md-0 text-body-secondary text-decoration-none lh-1"
-      >
-        {/*   <svg className="bi" width="30" height="24">
-          <use xlink:href="#bootstrap" />
-        </svg> */}
-      </a>
       <footer className="py-3 my-4">
-        <ul className="nav justify-content-center border-bottom pb-3 mb-3">
+        <ul className="nav justify-content-center border-bottom pb-1 mb-3">
           <li className="nav-item">
-            <a href="#" className="nav-link px-2 text-body-secondary">
+            <Link to="/" className="nav-link px-2 text-body-secondary">
               Home
-            </a>
+            </Link>
           </li>
           <li className="nav-item">
-            <a href="#" className="nav-link px-2 text-body-secondary">
-              Features
-            </a>
-          </li>
-          <li className="nav-item">
-            <a href="#" className="nav-link px-2 text-body-secondary">
-              Pricing
-            </a>
-          </li>
-          <li className="nav-item">
-            <a href="#" className="nav-link px-2 text-body-secondary">
-              FAQs
-            </a>
-          </li>
-          <li className="nav-item">
-            <a href="#" className="nav-link px-2 text-body-secondary">
-              About
-            </a>
+            <Link to="/dashboard" className="nav-link px-2 text-body-secondary">
+              Dashboard
+            </Link>
           </li>
         </ul>
         <p className="text-center text-body-secondary">
-          &copy; 2023 Company, Inc
+          Created By:{' '}
+          {authors.map((author) => {
+            return (
+              <span key={author.id}>
+                <a target="_blank" href={author.link}>
+                  {author.name}
+                </a>{' '}
+                |{' '}
+              </span>
+            );
+          })}
+          &copy; {new Date().getFullYear()} LinksApp
         </p>
       </footer>
     </div>

--- a/src/utils/constants.jsx
+++ b/src/utils/constants.jsx
@@ -1,0 +1,22 @@
+export const authors = [
+  {
+    name: 'Anderson',
+    link: 'https://github.com/fm-anderson',
+    id: 'fm-anderson',
+  },
+  {
+    name: 'Kirsten',
+    link: 'https://github.com/andkirsten',
+    id: 'andkirsten',
+  },
+  {
+    name: 'Michael',
+    link: 'https://github.com/Michaeljaurigue',
+    id: 'Michaeljaurigue',
+  },
+  {
+    name: 'Tyler',
+    link: 'https://github.com/Wylerlight',
+    id: 'Wylerlight',
+  },
+];


### PR DESCRIPTION
## What has been done?
- router `Link` tag added
- Year generated by JS
- Authors added

### Usage
Replaced `a` tags for `Link` tags to add routes navigation logic.
The year was hard coded and would have to be manually updated every year.